### PR TITLE
Add autoload file into custom-theme-load-path

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ wget https://raw.githubusercontent.com/Everblush/doomemacs/main/everblush-theme.
 ```
 then you can enable the theme in your config.el (you should know how to do it right?)
 
+If you use straight and use-package
+
+```emacs-lisp
+  (use-package doom-everblush-theme
+    :straight (doom-everblush-theme :type git :host github :repo "Everblush/doomemacs"))
+```
 ## Credits
 
 - [SamuelNihBos](https://github.com/samuelnihbos)

--- a/doom-everblush-theme.el
+++ b/doom-everblush-theme.el
@@ -1,4 +1,13 @@
-;;; everblush-theme.el --- based on everblush colorscheme by Mangeshrex -*- lexical-binding: t; no-byte-compile: t; -*-
+;;; doom-everblush-theme.el --- Based on everblush colorscheme by Mangeshrex -*- lexical-binding: t; no-byte-compile: t; -*-
+
+;; Maintainer: Mangeshrex
+;; Version: 0.1.0
+;; Homepage: https://github.com/Everblush/doomemacs
+;; Package-Requires: ((emacs "24.1") (doom-themes "2.3.0"))
+
+
+;;; Commentary:
+;;
 ;;; Code:
 
 (require 'doom-themes)
@@ -7,31 +16,31 @@
 ;;
 ;;; Variables
 
-(defgroup everblush-theme nil
-  "Options for the `doom-one' theme."
+(defgroup doom-everblush-theme nil
+  "Options for the `doom-everblush' theme."
   :group 'doom-themes)
 
-(defcustom everblush-brighter-modeline nil
+(defcustom doom-everblush-brighter-modeline nil
   "If non-nil, more vivid colors will be used to style the mode-line."
-  :group 'everblush-theme
+  :group 'doom-everblush-theme
   :type 'boolean)
 
-(defcustom everblush-brighter-comments nil
+(defcustom doom-everblush-brighter-comments nil
   "If non-nil, comments will be highlighted in more vivid colors."
-  :group 'everblush-theme
+  :group 'doom-everblush-theme
   :type 'boolean)
 
-(defcustom everblush-padded-modeline doom-themes-padded-modeline
+(defcustom doom-everblush-padded-modeline doom-themes-padded-modeline
   "If non-nil, adds a 4px padding to the mode-line.
 Can be an integer to determine the exact padding."
-  :group 'everblush-theme
+  :group 'doom-everblush-theme
   :type '(choice integer boolean))
 
 
 ;;
 ;;; Theme definition
 
-(def-doom-theme everblush
+(def-doom-theme doom-everblush
   "A beautiful and dark vim colorscheme ported to doom emacs."
 
   ;; name        default   256           16
@@ -78,9 +87,9 @@ Can be an integer to determine the exact padding."
    (vertical-bar   (doom-darken base1 0.1))
    (selection      dark-blue)
    (builtin        magenta)
-   ;;(comments       (if everblush-brighter-comments dark-cyan base5))
+   ;;(comments       (if doom-everblush-brighter-comments dark-cyan base5))
    (comments       grey)
-   (doc-comments   (doom-lighten (if everblush-brighter-comments dark-cyan base5) 0.25))
+   (doc-comments   (doom-lighten (if doom-everblush-brighter-comments dark-cyan base5) 0.25))
    (constants      violet)
    (functions      orange)
    (keywords       teal)
@@ -103,39 +112,39 @@ Can be an integer to determine the exact padding."
    ;; mandatory for derived themes.
    (modeline-fg              fg)
    (modeline-fg-alt          base5)
-   (modeline-bg              (if everblush-brighter-modeline
+   (modeline-bg              (if doom-everblush-brighter-modeline
                                  (doom-darken blue 0.45)
                                (doom-darken bg-alt 0.1)))
-   (modeline-bg-alt          (if everblush-brighter-modeline
+   (modeline-bg-alt          (if doom-everblush-brighter-modeline
                                  (doom-darken blue 0.475)
                                `(,(doom-darken (car bg-alt) 0.15) ,@(cdr bg))))
    (modeline-bg-inactive     `(,(car bg-alt) ,@(cdr base1)))
    (modeline-bg-inactive-alt `(,(doom-darken (car bg-alt) 0.1) ,@(cdr bg)))
 
    (-modeline-pad
-    (when everblush-padded-modeline
-      (if (integerp everblush-padded-modeline) everblush-padded-modeline 4))))
+    (when doom-everblush-padded-modeline
+      (if (integerp doom-everblush-padded-modeline) doom-everblush-padded-modeline 4))))
 
 
   ;;;; Base theme face overrides
   (((line-number &override) :foreground base4)
    ((line-number-current-line &override) :foreground fg)
    ((font-lock-comment-face &override)
-    :background (if everblush-brighter-comments (doom-lighten bg 0.05)))
+    :background (if doom-everblush-brighter-comments (doom-lighten bg 0.05)))
    (mode-line
     :background modeline-bg :foreground modeline-fg
     :box (if -modeline-pad `(:line-width ,-modeline-pad :color ,modeline-bg)))
    (mode-line-inactive
     :background modeline-bg-inactive :foreground modeline-fg-alt
     :box (if -modeline-pad `(:line-width ,-modeline-pad :color ,modeline-bg-inactive)))
-   (mode-line-emphasis :foreground (if everblush-brighter-modeline base8 highlight))
+   (mode-line-emphasis :foreground (if doom-everblush-brighter-modeline base8 highlight))
 
    ;;;; css-mode <built-in> / scss-mode
    (css-proprietary-property :foreground orange)
    (css-property             :foreground green)
    (css-selector             :foreground blue)
    ;;;; doom-modeline
-   (doom-modeline-bar :background (if everblush-brighter-modeline modeline-bg highlight))
+   (doom-modeline-bar :background (if doom-everblush-brighter-modeline modeline-bg highlight))
    (doom-modeline-buffer-file :inherit 'mode-line-buffer-id :weight 'bold)
    (doom-modeline-buffer-path :inherit 'mode-line-emphasis :weight 'bold)
    (doom-modeline-buffer-project-root :foreground green :weight 'bold)
@@ -163,6 +172,11 @@ Can be an integer to determine the exact padding."
     :box (if -modeline-pad `(:line-width ,-modeline-pad :color ,modeline-bg-inactive-alt))))
 
   ;;;; Base theme variable overrides-
-  ())
+  ;; ()
+  )
 
-;;; everblush-theme.el ends here
+;;;###autoload
+(when load-file-name
+  (add-to-list 'custom-theme-load-path
+               (file-name-as-directory (file-name-directory load-file-name))))
+;;; doom-everblush-theme.el ends here


### PR DESCRIPTION
I wanted to load this package using `use-package+straight`, which meant it needed an autoload.

Additionally, because this is nominally supposed to be a `doom-theme`, so I updated the naming of the variables to the `doom-theme` style ie `doom-everblush-*`. Updating the naming scheme might make this easier to merge into `doom-themes` if that is still your intent.